### PR TITLE
create basic cart panel with toggle function and buttons

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import PageWrapper from "./components/PageWrapper/PageWrapper";
 import Landing from "./pages/Landing";
 import About from "./pages/About/About";
 import Wishlist from "./pages/Wishlist/Wishlist";
@@ -15,6 +16,7 @@ class App extends Component {
     this.state = {
       watchData: [],
       loggedIn: false,
+      showCart: false,
       user: ''
     };
   }
@@ -53,54 +55,64 @@ class App extends Component {
     });
   }
 
+  toggleCart = () => {
+    this.setState({ showCart: !this.state.showCart });
+  }
 
   render() {
     return (
       <Router>
-        <Switch>
-          <Route exact path="/">
-            {routeProps => (
-              <Landing
-                {...routeProps}
-                loggedIn={this.state.loggedIn}
-                logout={this.logout}
-                watchData={this.state.watchData}
-              />
-            )}
-          </Route>
+        <PageWrapper
+          loggedIn={this.state.loggedIn}
+          logout={this.logout}
+          showCart={this.state.showCart}
+          toggleCart={this.toggleCart}
+        >
+          <Switch>
+            <Route exact path="/">
+              {routeProps => (
+                <Landing
+                  {...routeProps}
+                  loggedIn={this.state.loggedIn}
+                  logout={this.logout}
+                  watchData={this.state.watchData}
+                />
+              )}
+            </Route>
 
-          <Route exact path="/about">
-            {routeProps => (
-              <About
-                {...routeProps}
-                loggedIn={this.state.loggedIn}
-                logout={this.logout}
-              />
-            )}
-          </Route>
+            <Route exact path="/about">
+              {routeProps => (
+                <About
+                  {...routeProps}
+                  loggedIn={this.state.loggedIn}
+                  logout={this.logout}
+                />
+              )}
+            </Route>
 
-          <Route exact path="/wishlist">
-            {routeProps => (
-              <Wishlist
-                {...routeProps}
-                loggedIn={this.state.loggedIn}
-                logout={this.logout}
-              />
-            )}
-          </Route>
+            <Route exact path="/wishlist">
+              {routeProps => (
+                <Wishlist
+                  {...routeProps}
+                  loggedIn={this.state.loggedIn}
+                  logout={this.logout}
+                />
+              )}
+            </Route>
 
-          <Route exact path="/signin">
-            {routeProps => (
-              <Authenticate
-                {...routeProps}
-                loggedIn={this.state.loggedIn}
-                login={this.login}
-                logout={this.logout}
-                signup={this.signup}
-              />
-            )}
-          </Route>
-        </Switch>
+            <Route exact path="/signin">
+              {routeProps => (
+                <Authenticate
+                  {...routeProps}
+                  loggedIn={this.state.loggedIn}
+                  login={this.login}
+                  logout={this.logout}
+                  signup={this.signup}
+                />
+              )}
+            </Route>
+          </Switch>
+        </PageWrapper>
       </Router>
     );
   }

--- a/client/src/components/Cart/Cart.jsx
+++ b/client/src/components/Cart/Cart.jsx
@@ -1,0 +1,24 @@
+import React, { PureComponent } from 'react';
+import "./Cart.scss";
+
+class Cart extends PureComponent {
+
+  render() {
+    let cartStyle;
+    if (this.props.showCart) cartStyle = {};
+    else cartStyle = { transform: "translateX(100%)" };
+    return (
+      <div className="cart" style={cartStyle}>
+        <button
+          className="cart__close-btn"
+          onClick={this.props.toggleCart}
+        >
+          &times;
+        </button>
+        <h2>Here's the cart!</h2>
+      </div >
+    );
+  }
+}
+
+export default Cart;

--- a/client/src/components/Cart/Cart.scss
+++ b/client/src/components/Cart/Cart.scss
@@ -1,0 +1,31 @@
+@import "../../styles/_variables.sass";
+
+.cart {
+  background: #111;
+  height: 100%;
+  min-width: 400px;
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 30%;
+  transition: transform 0.3s;
+  z-index: 9;
+  h2 {
+    color: white;
+    font-size: 3rem;
+    text-align: center;
+    padding: 20px;
+  }
+}
+
+.cart__close-btn {
+  background: transparent;
+  border: none;
+  color: white;
+  cursor: pointer;
+  float: right;
+  font-size: 2.5rem;
+  margin-top: 5px;
+  margin-right: 5px;
+  outline: transparent;
+}

--- a/client/src/components/NavBar/NavBar.jsx
+++ b/client/src/components/NavBar/NavBar.jsx
@@ -20,7 +20,7 @@ const NavBar = props => (
                   <Link to="/wishlist">Wishlist</Link>
                 </li>
                 <li>
-                  <Link to="#">Cart</Link>
+                  <button onClick={props.toggleCart}>Cart</button>
                 </li>
                 <li>
                   <button onClick={props.logout}>Sign Out</button>

--- a/client/src/components/PageWrapper/PageWrapper.jsx
+++ b/client/src/components/PageWrapper/PageWrapper.jsx
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import NavBar from "../NavBar/NavBar";
+import Cart from "../Cart/Cart";
+import "./PageWrapper.scss";
+
+class PageWrapper extends Component {
+  render() {
+    return (
+      <div className="page-wrapper">
+        <NavBar
+          loggedIn={this.props.loggedIn}
+          logout={this.props.logout}
+          toggleCart={this.props.toggleCart}
+        />
+
+        <Cart
+          showCart={this.props.showCart}
+          toggleCart={this.props.toggleCart}
+        />
+
+        {this.props.children}
+
+      </div>
+    );
+  }
+}
+
+export default PageWrapper;

--- a/client/src/components/PageWrapper/PageWrapper.scss
+++ b/client/src/components/PageWrapper/PageWrapper.scss
@@ -1,0 +1,6 @@
+@import "../../styles/_variables.sass";
+
+.page-wrapper {
+  min-height: 100vh;
+  min-width: 100vw;
+}

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -4,10 +4,10 @@ import "./About.sass";
 
 const About = props => (
   <div className="about">
-    <NavBar
+    {/* <NavBar
       loggedIn={props.loggedIn}
       logout={props.logout}
-    />
+    /> */}
     
     <section className="about-section">
       <div className="about-card">

--- a/client/src/pages/About/About.sass
+++ b/client/src/pages/About/About.sass
@@ -1,8 +1,8 @@
 @import '../../styles/_variables.sass'
 
 .about
-    width: 100vw
-    height: 100vh
+    width: 100%
+    height: 100%
 
 .about-section
     position: relative

--- a/client/src/pages/Authenticate/Authenticate.jsx
+++ b/client/src/pages/Authenticate/Authenticate.jsx
@@ -15,10 +15,10 @@ class Authenticate extends Component {
     if (this.props.loggedIn) this.props.history.goBack();
     return (
       <Fragment>
-        <NavBar
+        {/* <NavBar
           loggedIn={this.props.loggedIn}
           logout={this.props.logout}
-        />
+        /> */}
 
         {this.state.loginForm
           ? (

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -9,10 +9,10 @@ const Landing = props => {
 
   return (
     <div>
-      <NavBar
+      {/* <NavBar
         loggedIn={props.loggedIn}
         logout={props.logout}
-      />
+      /> */}
       
       <ProductGrid
         watchData={props.watchData}

--- a/client/src/pages/Wishlist/Wishlist.jsx
+++ b/client/src/pages/Wishlist/Wishlist.jsx
@@ -49,10 +49,10 @@ class Wishlist extends React.Component {
 
     return (
       <div className="wishlist">
-        <NavBar
+        {/* <NavBar
           loggedIn={this.props.loggedIn}
           logout={this.props.logout}
-        />
+        /> */}
 
         <Modal>
           {modalProps => (


### PR DESCRIPTION

- Created basic cart panel with toggle function and buttons
- Wrapped whole app in a PageWrapper component to make it easier to keep the cart panel (and associated state) available no matter which page of the app you're on. This seemed like a good way to handle having the cart as a panel rather than its own page.
- Possible drawback is more page re-renders when adding items to cart and thus setting state.
     - we might be able to control this by using Pure Components; it also might turn out to not be a big deal. We can test it as we go. It won't be too hard to change the Cart into its own page if it seems like a better idea later.